### PR TITLE
Update LcovParser field value parsing

### DIFF
--- a/.changeset/old-kiwis-wait.md
+++ b/.changeset/old-kiwis-wait.md
@@ -1,0 +1,5 @@
+---
+"@friedemannsommer/lcov-parser": patch
+---
+
+Fixed a bug which stripped everything up to the last colon, when parsing field values that contain colons.

--- a/src/tests/parser.spec.ts
+++ b/src/tests/parser.spec.ts
@@ -225,3 +225,32 @@ describe('LcovParser - empty fields', (): void => {
         expect(parser.read()).to.eql(getParseResult(Variant.None, null, false, true))
     })
 })
+
+describe('LcovParser - Paths containing colons', (): void => {
+    it('should process valid Windows like path', (): void => {
+        const parser = new LcovParser(defaultFieldNames)
+
+        parser.write(
+            Buffer.from(
+                getRawLcov(
+                    defaultFieldNames.filePath,
+                    'C:\\Users\\Example\\Documents\\Projects\\example\\src\\example.file'
+                )
+            )
+        )
+
+        expect(parser.read()).to.eql(
+            getParseResult(Variant.FilePath, ['C:\\Users\\Example\\Documents\\Projects\\example\\src\\example.file'])
+        )
+        expect(parser.read()).to.eql(getParseResult(Variant.None, null, true))
+    })
+
+    it('should process a path containing multiple colons', (): void => {
+        const parser = new LcovParser(defaultFieldNames)
+
+        parser.write(Buffer.from(getRawLcov(defaultFieldNames.filePath, '/this/is/a/path:with:colons')))
+
+        expect(parser.read()).to.eql(getParseResult(Variant.FilePath, ['/this/is/a/path:with:colons']))
+        expect(parser.read()).to.eql(getParseResult(Variant.None, null, true))
+    })
+})


### PR DESCRIPTION
Fixed the parsing of field values that contain colons.

This unfortunate bug removed everything up to the last colon in the field value.
With these changes, the bug mentioned in #140 is fixed.