### PR TITLE
Support C++ demangling function name

### DIFF
--- a/src/lib/transform-result.ts
+++ b/src/lib/transform-result.ts
@@ -133,7 +133,7 @@ export function transformFunctionExecution(result: ParseResult<Variant.FunctionE
 
     if (result.value !== null && result.value.length >= 2) {
         hit = parseInteger(result.value[0])
-        name = result.value[1]
+        name = result.value.slice(1).join(',')
     }
 
     return {
@@ -156,7 +156,7 @@ export function transformFunctionLocation(result: ParseResult<Variant.FunctionLo
         if (lineEnd < lineStart || result.value.length === 2) {
             name = result.value[1]
         } else if (result.value.length >= 3) {
-            name = result.value[2]
+            name = result.value.slice(2).join(',')
         }
     }
 
@@ -224,7 +224,7 @@ export function transformFunctionAlias(result: ParseResult<Variant.FunctionAlias
     if (result.value != null && result.value.length >= 3) {
         index = parseInteger(result.value[0])
         hit = parseInteger(result.value[1])
-        name = result.value[2]
+        name = result.value.slice(2).join(',')
     }
 
     return {

--- a/src/lib/transform-result.ts
+++ b/src/lib/transform-result.ts
@@ -153,9 +153,11 @@ export function transformFunctionLocation(result: ParseResult<Variant.FunctionLo
         lineStart = parseInteger(result.value[0])
         lineEnd = parseInteger(result.value[1])
 
-        if (lineEnd < lineStart || result.value.length === 2) {
+        if (result.value.length === 2) {
             name = result.value[1]
-        } else if (result.value.length >= 3) {
+        } else if (lineEnd < lineStart) {
+            name = result.value.slice(1).join(',')
+        } else {
             name = result.value.slice(2).join(',')
         }
     }


### PR DESCRIPTION
lcov support [--demangle_cpp](https://github.com/linux-test-project/lcov/blob/5186f7394417292537d17b9a9a30f8c06bedc16c/man/geninfo.1#L73C2-L73C12) option. This option tells  `genhtml/lcov/geninfo`  to  demangle  C++  function  names   in  function overviews.

from
```
FN:4,_ZN5MyApp10Calculator3addEii
FNDA:1,_ZN5MyApp10Calculator3addEii
```
to
```
FN:4,MyApp::Calculator::add(int, int)
FNDA:1,MyApp::Calculator::add(int, int)
```